### PR TITLE
fix: add check dst reg  and ut func

### DIFF
--- a/pkg/optimizer/filter.go
+++ b/pkg/optimizer/filter.go
@@ -67,9 +67,13 @@ func (s *Section) applyCompaction() {
 
 		// Look for LSH followed by RSH pattern (bit field extraction)
 		if inst1.Opcode == 0x67 && inst2.Opcode == 0x77 {
-			if inst1.Raw[8:] == "20000000" && inst2.Raw[8:] == "20000000" {
-				candidates = append(candidates, i)
+			if inst1.Raw[8:] != "20000000" || inst2.Raw[8:] != "20000000" {
+				continue
 			}
+			if inst1.DstReg != inst2.DstReg {
+				continue
+			}
+			candidates = append(candidates, i)
 		}
 	}
 

--- a/pkg/optimizer/filter_test.go
+++ b/pkg/optimizer/filter_test.go
@@ -237,3 +237,195 @@ func TestApplyConstantPropagation(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyCompaction(t *testing.T) {
+	tests := []struct {
+		name          string
+		instructions  []string
+		expectedInsts []string
+		expectedNOPs  []int
+	}{
+		{
+			name: "basic LSH+RSH compaction",
+			instructions: []string{
+				"6701000020000000", // lsh r1, 32
+				"7701000020000000", // rsh r1, 32
+			},
+			expectedInsts: []string{
+				"bc11000000000000", // mov32 r1, r1
+				"0500000000000000", // NOP
+			},
+			expectedNOPs: []int{1},
+		},
+		{
+			name: "different register compaction",
+			instructions: []string{
+				"6702000020000000", // lsh r2, 32
+				"7702000020000000", // rsh r2, 32
+			},
+			expectedInsts: []string{
+				"bc22000000000000", // mov32 r2, r2
+				"0500000000000000", // NOP
+			},
+			expectedNOPs: []int{1},
+		},
+		{
+			name: "multiple consecutive compactions",
+			instructions: []string{
+				"6701000020000000", // lsh r1, 32
+				"7701000020000000", // rsh r1, 32
+				"6702000020000000", // lsh r2, 32
+				"7702000020000000", // rsh r2, 32
+			},
+			expectedInsts: []string{
+				"bc11000000000000", // mov32 r1, r1
+				"0500000000000000", // NOP
+				"bc22000000000000", // mov32 r2, r2
+				"0500000000000000", // NOP
+			},
+			expectedNOPs: []int{1, 3},
+		},
+		{
+			name: "non-consecutive compaction pattern",
+			instructions: []string{
+				"6701000020000000", // lsh r1, 32
+				"7701000020000000", // rsh r1, 32
+				"b70300000f000000", // mov r3, 15 (unrelated instruction)
+				"6704000020000000", // lsh r4, 32
+				"7704000020000000", // rsh r4, 32
+			},
+			expectedInsts: []string{
+				"bc11000000000000", // mov32 r1, r1
+				"0500000000000000", // NOP
+				"b70300000f000000", // unchanged
+				"bc44000000000000", // mov32 r4, r4
+				"0500000000000000", // NOP
+			},
+			expectedNOPs: []int{1, 4},
+		},
+		{
+			name: "wrong immediate value - should not compact",
+			instructions: []string{
+				"6701000010000000", // lsh r1, 16 (not 32)
+				"7701000010000000", // rsh r1, 16
+			},
+			expectedInsts: []string{
+				"6701000010000000", // unchanged
+				"7701000010000000", // unchanged
+			},
+			expectedNOPs: []int{},
+		},
+		{
+			name: "wrong opcode - should not compact",
+			instructions: []string{
+				"6701000020000000", // lsh r1, 32
+				"7f01000020000000", // arsh r1, 32 (wrong opcode)
+			},
+			expectedInsts: []string{
+				"6701000020000000", // unchanged
+				"7f01000020000000", // unchanged
+			},
+			expectedNOPs: []int{},
+		},
+		{
+			name: "single instruction - should not compact",
+			instructions: []string{
+				"6701000020000000", // lsh r1, 32 (no following rsh)
+			},
+			expectedInsts: []string{
+				"6701000020000000", // unchanged
+			},
+			expectedNOPs: []int{},
+		},
+		{
+			name: "empty instructions",
+			instructions: []string{},
+			expectedInsts: []string{},
+			expectedNOPs:  []int{},
+		},
+		{
+			name: "different registers - should not compact",
+			instructions: []string{
+				"6701000020000000", // lsh r1, 32
+				"7702000020000000", // rsh r2, 32 (different register)
+			},
+			expectedInsts: []string{
+				"6701000020000000", // unchanged
+				"7702000020000000", // unchanged
+			},
+			expectedNOPs: []int{},
+		},
+		{
+			name: "mixed valid and invalid patterns",
+			instructions: []string{
+				"6701000020000000", // lsh r1, 32
+				"7701000020000000", // rsh r1, 32 (valid)
+				"6702000010000000", // lsh r2, 16
+				"7702000010000000", // rsh r2, 16 (invalid - wrong immediate)
+				"6703000020000000", // lsh r3, 32
+				"7703000020000000", // rsh r3, 32 (valid)
+			},
+			expectedInsts: []string{
+				"bc11000000000000", // mov32 r1, r1
+				"0500000000000000", // NOP
+				"6702000010000000", // unchanged
+				"7702000010000000", // unchanged
+				"bc33000000000000", // mov32 r3, r3
+				"0500000000000000", // NOP
+			},
+			expectedNOPs: []int{1, 5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create section with test data
+			section := &Section{
+				Name:         "test",
+				Instructions: make([]*bpf.Instruction, len(tt.instructions)),
+				Dependencies: make([]DependencyInfo, len(tt.instructions)),
+			}
+
+			// Parse instructions
+			for i, hexStr := range tt.instructions {
+				inst, err := bpf.NewInstruction(hexStr)
+				if err != nil {
+					t.Fatalf("Failed to parse instruction %d: %v", i, err)
+				}
+				section.Instructions[i] = inst
+			}
+
+			// Apply compaction
+			section.applyCompaction()
+
+			// Check results
+			for i, expectedHex := range tt.expectedInsts {
+				actualHex := section.Instructions[i].ToHex()
+				if actualHex != expectedHex {
+					t.Errorf("Instruction %d: expected %s, got %s", i, expectedHex, actualHex)
+				}
+			}
+
+			// Check NOPs
+			for _, nopIdx := range tt.expectedNOPs {
+				if !section.Instructions[nopIdx].IsNOP() {
+					t.Errorf("Instruction %d should be NOP", nopIdx)
+				}
+			}
+
+			// Check that non-NOP instructions are not NOPs
+			for i := 0; i < len(section.Instructions); i++ {
+				shouldBeNOP := false
+				for _, nopIdx := range tt.expectedNOPs {
+					if i == nopIdx {
+						shouldBeNOP = true
+						break
+					}
+				}
+				if !shouldBeNOP && section.Instructions[i].IsNOP() {
+					t.Errorf("Instruction %d should not be NOP", i)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- 在filter_test.go中新增了TestApplyCompaction函数，涵盖多种指令压缩场景。
- 测试用例包括基本压缩、不同寄存器压缩、连续和非连续压缩模式等，确保压缩逻辑的正确性。
- 更新了applyCompaction函数的逻辑，以确保仅在满足特定条件时进行压缩，提升了代码的健壮性。